### PR TITLE
fix: pnpm approve builds for esbuild, msw, sharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild", "msw", "sharp"]
+  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "msw", "sharp"]
-  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@biomejs/biome": "^2.4.15",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  msw: true
+  sharp: true


### PR DESCRIPTION
Resolve ERR_PNPM_IGNORED_BUILDS by explicitly approving build scripts for esbuild, msw, and sharp.