### PR TITLE
fix: adjust video aspect ratio for smartphone

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -8,7 +8,7 @@ const videoAlt = "ub-MOJI hero video";
 <section class="flex min-h-svh w-full flex-col justify-center bg-background pb-10 pt-6" data-testid="hero">
   <div class="mx-auto w-full max-w-5xl px-4">
     <div class="relative grid place-items-center">
-      <div class="relative w-full overflow-hidden rounded-[2rem] border border-border/60 bg-black/30 shadow-[0_24px_80px_rgba(0,0,0,0.25)] aspect-[16/9] max-h-[70svh] min-h-[18rem]">
+      <div class="relative w-full overflow-hidden rounded-[2rem] border border-border/60 bg-black/30 shadow-[0_24px_80px_rgba(0,0,0,0.25)] aspect-[9/16] max-h-[70svh] min-h-[18rem] sm:aspect-[16/9]">
         <div class="absolute inset-0">
           <video
             class="h-full w-full object-cover motion-reduce:hidden"


### PR DESCRIPTION
## Related Issue

close #313

## Changes

Video in the Hero Section is displayed in portrait orientation on smartphones.

## Notes