### PR TITLE
fix: add layout attribute to footer logo image

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,6 +20,7 @@ const locale = resolveLocale(lang);
         alt={t(locale, "footerLogoAlt")}
         width={36}
         height={36}
+        layout="fixed"
         class="size-9 object-contain"
       />
       <div class="flex flex-col gap-0.5">


### PR DESCRIPTION
## Related Issue

close #309 

## Changes

Specify `layout=“fixed”` for the Responsive Images feature to ensure images display clearly even in high-DPI environments.

## Notes